### PR TITLE
fix: input description must have unique index

### DIFF
--- a/scripts/pytorch_custom_op/hpu_custom_searchsorted.cpp
+++ b/scripts/pytorch_custom_op/hpu_custom_searchsorted.cpp
@@ -17,9 +17,9 @@ bool register_custom_searchsorted() {
     habana::custom_op::InputDesc input_a_desc{
         habana::custom_op::input_type::TENSOR, 0};
     habana::custom_op::InputDesc input_b_desc{
-        habana::custom_op::input_type::TENSOR, 0};
+        habana::custom_op::input_type::TENSOR, 1};
     habana::custom_op::InputDesc input_c_desc{
-        habana::custom_op::input_type::SCALAR, 0};
+        habana::custom_op::input_type::SCALAR, 2};
 
     std::vector<habana::custom_op::InputDesc> inputs_desc{
         input_a_desc, input_b_desc, input_c_desc};


### PR DESCRIPTION
I've found some trivial coding errors in your example codes.